### PR TITLE
Guard against empty cmake generator expressions

### DIFF
--- a/cmake/modules/KstPchSupport.cmake
+++ b/cmake/modules/KstPchSupport.cmake
@@ -41,7 +41,7 @@ macro(kst_add_pch_rule  _header _sources _lib_type)
 		# first we have to find all compiler arguments
 		get_directory_property(_definitions COMPILE_DEFINITIONS)
 		foreach (_it ${_definitions})
-			list(APPEND _args "-D${_it}")
+			list(APPEND _args "$<$<BOOL:${_it}>:-D${_it}>")
 		endforeach()
 		
 		list(APPEND _args ${CMAKE_CXX_FLAGS})


### PR DESCRIPTION
COMPILER_DEFINITIONS can contain cmake generator expressions that evaluate to an empty string.
gcc fails when you pass -D without an expression as an argument.

This fixes building with cmake 3.0 which adds the following expression:
$<$NOT:$<CONFIG:Debug>:QT_NO_DEBUG>

My fix is probably incomplete but at least kst builds again.
COMPILE_DEFINITIONS_<CONFIG> is deprecated in 3.0 so I don't expect modules adding new expressions there.
