### PR TITLE
Fix preprocessor collision between kst and hdf5 headers.

### DIFF
--- a/src/datasources/hdf5/hdf5.h
+++ b/src/datasources/hdf5/hdf5.h
@@ -11,8 +11,8 @@
  ***************************************************************************/
 
 
-#ifndef HDF5_H
-#define HDF5_H
+#ifndef DATASOURCE_HDF5_H
+#define DATASOURCE_HDF5_H
 
 #include <datasource.h>
 #include <dataplugin.h>


### PR DESCRIPTION
In two files

* src/datasources/hdf5/hdf5.h
* /usr/include/hdf5/serial/hdf.h (Debian),

we have the standard preprocessor bumpf

	#ifndef HDF5_H
	#define HDF5_H

	[...]

	#endif

However, because both use the same token, the build fails.

This commit uses a longer token for the HDF5 version of the macro. Depending on your coding style, it might be better to rename the KST code from "hdf5.h" to "datasource_hdf5.h", and you might prefer to do that with the code in addition to the headers.

Fixes #22.