### PR TITLE
Update netCDF datasource plugin to work with modern netCDF4 C++ bindings

### DIFF
--- a/cmake/modules/FindNetcdf.cmake
+++ b/cmake/modules/FindNetcdf.cmake
@@ -17,11 +17,11 @@ if(NOT NETCDF_INCLUDEDIR)
 
 if(NOT kst_cross)
 	include(FindPkgConfig)
-  pkg_check_modules(NETCDF QUIET netcdf)
+  pkg_check_modules(NETCDF netcdf netcdf-cxx4)
 endif()
 
 if(NETCDF_INCLUDEDIR AND NETCDF_LIBRARIES)
-	FIND_LIBRARY(NETCDF_LIBRARY_CPP netcdf_c++ 
+	FIND_LIBRARY(NETCDF_LIBRARY_CPP netcdf_c++4
 		HINTS ${NETCDF_LIBRARY_DIRS})	
 	set(NETCDF_LIBRARY_C -L${NETCDF_LIBRARY_DIRS} ${NETCDF_LIBRARIES} CACHE STRING "" FORCE)
 else()
@@ -46,9 +46,9 @@ else()
 	
 	find_netcdf_lib(netcdf_c         netcdf)
 	find_netcdf_lib(netcdf_c_debug   netcdfd)
-	find_netcdf_lib(netcdf_cpp       netcdf_c++)
-	find_netcdf_lib(netcdf_cpp_debug netcdf_c++d)
-	
+	find_netcdf_lib(netcdf_cpp       netcdf_c++4)
+	find_netcdf_lib(netcdf_cpp_debug netcdf_c++4d)
+
 	if(netcdf_c AND netcdf_c_debug)
 		set(NETCDF_LIBRARY_C optimized ${netcdf_c} debug ${netcdf_c_debug} CACHE STRING "" FORCE)
 	endif()

--- a/src/datasources/netcdf/netcdfplugin.cpp
+++ b/src/datasources/netcdf/netcdfplugin.cpp
@@ -126,13 +126,11 @@ int NetCdfPlugin::understands(QSettings *cfg, const QString& filename) const
       return 0;
     }
 
-    NcFile *ncfile = new NcFile(filename.toUtf8().data());
-    if (ncfile->is_valid()) {
+    netCDF::NcFile ncfile(filename.toUtf8().data(), netCDF::NcFile::read);
+    if (!ncfile.isNull()) {
       KST_DBG qDebug() << filename << " looks like netCDF !" << endl;
-      delete ncfile;
       return 80;
     } else {
-      delete ncfile;
       return 0;
     }
   }

--- a/src/datasources/netcdf/netcdfsource.h
+++ b/src/datasources/netcdf/netcdfsource.h
@@ -22,8 +22,7 @@
 #include "datasource.h"
 #include "dataplugin.h"
 
-#include <netcdf.h>
-#include <netcdfcpp.h>
+#include <netcdf>
 
 
 class DataInterfaceNetCdfScalar;
@@ -71,10 +70,7 @@ class NetcdfSource : public Kst::DataSource {
     QMap<QString, int> _frameCounts;
 
     int _maxFrameCount;
-    NcFile *_ncfile;
-
-    // we must hold an NcError to overwrite the exit-on-error behaviour of netCDF
-    NcError _ncErr;
+    netCDF::NcFile *_ncfile;
 
     QMap<QString, QString> _strings;
 


### PR DESCRIPTION
We (South Pole Telescope) occasionally need to generate netCDF data for live viewing with kst2.  Kst2 is by far the most efficient tool for live streaming detector data, but the netCDF plugin is quite out of date, and our netCDF data generator creates files in the newer netCDF4 format.  This PR is meant to update the netCDF datasource plugin to link against the netCDF4 C++ bindings instead of the older version.

I am currently at pole, and unfortunately don't have the (electronic or mental) bandwidth to figure out how to update the build system properly to integrate into the CI or packaging framework, but I wanted to at least get this code posted for review / integration into later releases if possible.  I've enabled edits by maintainers on this branch, so feel free to make changes on this PR or otherwise.

Thank you!