### PR TITLE
[Improve] reset SelectionRect (cursor)  in all plots of current view while levelEvent

### DIFF
--- a/src/libkstapp/plotrenderitem.cpp
+++ b/src/libkstapp/plotrenderitem.cpp
@@ -974,13 +974,20 @@ void PlotRenderItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event) {
 
   _highlightPointActive = false;
 
+  QList<PlotItem*> allPlots = PlotItemManager::plotsForView(view());
+  foreach(PlotItem* plot, allPlots) {
+    if (plot->renderItem()) {
+      plot->renderItem()->resetSelectionRect();
+      plot->renderItem()->_highlightPointActive = false;
+    }
+  }
+
   if (view()->viewMode() != View::Data) {
     event->ignore();
     return;
   }
 
   clearFocus();
-  resetSelectionRect();
 
   updateCursor(event->pos());
 


### PR DESCRIPTION
Currently, after toggling tied on multiple plots, if the cursor is moved out of the current plot, the SelectionRect will be removed only from the current plot and will remain in the remaining plots for a long time, until the mouse moves into one of the plots again, which may interfere with data reading and screenshotting.

Specifically, the behavior is as follows:

![original](https://github.com/user-attachments/assets/8cc5e2b8-c81c-4720-97a6-ac8e234858e6)

The purpose of this PR is to modify hoverLeaveEvent so that when the cursor leaves a plot, all SelectionRect elements across all plots are removed, achieving a clean visual effect.

![new](https://github.com/user-attachments/assets/88a70420-b744-4812-ac12-d80fe176db6f)

